### PR TITLE
Added support for debug with block.

### DIFF
--- a/src/lcthw/dbg.h
+++ b/src/lcthw/dbg.h
@@ -11,6 +11,11 @@
 #define debug(M, ...) fprintf(stderr, "DEBUG %s:%d: " M "\n", __FILE__, __LINE__, ##__VA_ARGS__)
 #endif
 
+#ifdef NDEBUG
+#define debug_b(B)
+#else
+#define debug_b(B) B()
+#endif
 
 // do not try to be smart and make this go away on NDEBUG, the _debug
 // here means that it just doesn't print a message, it still does the


### PR DESCRIPTION
This is very useful when we need to debug the code more complex than printfs.
Tested with Apple clang version 3.1 (tags/Apple/clang-318.0.54) (based on LLVM 3.1svn)
Target: x86_64-apple-darwin11.4.0
Thread model: posix