### PR TITLE
LIBS should be LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS=-g -O2 -Wall -Wextra -Isrc -rdynamic -DNDEBUG $(OPTFLAGS)
-LIBS=$(OPTLIBS)
+LDFLAGS=$(OPTLIBS)
 PREFIX?=/usr/local
 
 SOURCES=$(wildcard src/**/*.c src/*.c)


### PR DESCRIPTION
Should LIBS be LDFLAGS here?

Using libs, I can't link to an external library, changing to LDFLAGS works.