### PR TITLE
using LDLIBS for linking the liblcthw library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build:
 
 # The Unit Tests
 .PHONY: tests
-tests: CFLAGS += $(TARGET)
+tests: LDLIBS += $(TARGET)
 tests: $(TESTS)
 	sh ./tests/runtests.sh
 


### PR DESCRIPTION
So the old cranky gcc doesn't complain. Besides it supposed to be a lib so it should go in LDLIBS don't you think?