### PR TITLE
Ex. 37: Add missing arg name in hashmap.h

### DIFF
--- a/src/lcthw/hashmap.h
+++ b/src/lcthw/hashmap.h
@@ -23,7 +23,7 @@ typedef struct HashmapNode {
 
 typedef int (*Hashmap_traverse_cb) (HashmapNode * node);
 
-Hashmap *Hashmap_create(Hashmap_compare compare, Hashmap_hash);
+Hashmap *Hashmap_create(Hashmap_compare compare, Hashmap_hash hash);
 void Hashmap_destroy(Hashmap * map);
 
 int Hashmap_set(Hashmap * map, void *key, void *data);


### PR DESCRIPTION
Just a minor typo fix.