### PR TITLE
darray.c clear function doesn't set end to zero

### DIFF
--- a/src/lcthw/darray.c
+++ b/src/lcthw/darray.c
@@ -33,6 +33,7 @@ void DArray_clear(DArray * array)
             }
         }
     }
+    array->end = 0;
 }
 
 static inline int DArray_resize(DArray * array, size_t newsize)


### PR DESCRIPTION
Added end zeroing on DArray_clear call.