### PR TITLE
Fix excessive realloc in DArray_pop

### DIFF
--- a/src/lcthw/darray.c
+++ b/src/lcthw/darray.c
@@ -109,8 +109,8 @@ void *DArray_pop(DArray * array)
     void *el = DArray_remove(array, array->end - 1);
     array->end--;
 
-    if (DArray_end(array) > (int)array->expand_rate
-            && DArray_end(array) % array->expand_rate) {
+    if (DArray_end(array) >= (int)array->expand_rate
+            && (DArray_end(array) % array->expand_rate) == 0) {
         DArray_contract(array);
     }
 

--- a/tests/darray_tests.c
+++ b/tests/darray_tests.c
@@ -94,16 +94,22 @@ char *test_push_pop()
         int *val = DArray_new(array);
         *val = i * 333;
         DArray_push(array, val);
+        mu_assert(((array->max - 1) % array->expand_rate) == 0,
+                  "Wrong max size.");
     }
 
     mu_assert(array->max == 1201, "Wrong max size.");
 
     for (i = 999; i >= 0; i--) {
         int *val = DArray_pop(array);
+        mu_assert(((array->max - 1) % array->expand_rate) == 0,
+                  "Wrong max size.");
         mu_assert(val != NULL, "Shouldn't get a NULL.");
         mu_assert(*val == i * 333, "Wrong value.");
         DArray_free(val);
     }
+
+    mu_assert(array->max == 301, "Wrong max size.");
 
     return NULL;
 }


### PR DESCRIPTION
Was reallocing on every pop *except* the one where it was supposed to realloc, basically every pop when the max was greater than the expand rate. I also changed the 1st condition when popping so that it correctly resizes to 301 now that it reallocs correctly.

I also added a couple checks to the tests so that after every push and pop it makes sure that max is a multiple of expand_rate + 1 (as long as we're just pushing/popping elements it should resize in increments of the expand_rate).