### PR TITLE
Suppress minunit compiler warning

### DIFF
--- a/tests/minunit.h
+++ b/tests/minunit.h
@@ -13,7 +13,7 @@
     message = test(); tests_run++; if (message) return message;
 
 #define RUN_TESTS(name) int main(int argc, char *argv[]) {\
-    argc = 1; \
+    argc++; \
     debug("----- RUNNING: %s", argv[0]);\
     printf("----\nRUNNING: %s\n", argv[0]);\
     char *result = name();\


### PR DESCRIPTION
minunit.h produces an 'unused argument argc' warning on GCC. Changing
'argc = 1' to 'argc++' removes the problem.