### PR TITLE
Fix so that library compiles under Ubuntu (17.04)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ TESTS=$(patsubst %.c,%,$(TEST_SRC))
 
 TARGET=build/liblcthw.a
 
+OS=$(shell lsb_release -si)
+ifeq ($(OS),Ubuntu)
+	LDLIBS=-llcthw -lbsd -L./build -lm
+endif
+
 # The Target Build
 all: $(TARGET) tests
 
@@ -27,7 +32,7 @@ build:
 
 # The Unit Tests
 .PHONY: tests
-tests: LDLIBS += $(TARGET)
+tests: LDLIBS += ${TARGET}
 tests: $(TESTS)
 	sh ./tests/runtests.sh
 
@@ -50,4 +55,3 @@ install: all
 check:
 	@echo Files with potentially dangerous functions.
 	@egrep '[^_.>a-zA-Z0-9](str(n?cpy|n?cat|xfrm|n?dup|str|pbrk|tok|_)|stpn?cpy|a?sn?printf|byte_)' $(SOURCES) || true
-

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build:
 
 # The Unit Tests
 .PHONY: tests
-tests: LDLIBS += ${TARGET}
+tests: LDLIBS += $(TARGET)
 tests: $(TESTS)
 	sh ./tests/runtests.sh
 
@@ -55,3 +55,4 @@ install: all
 check:
 	@echo Files with potentially dangerous functions.
 	@egrep '[^_.>a-zA-Z0-9](str(n?cpy|n?cat|xfrm|n?dup|str|pbrk|tok|_)|stpn?cpy|a?sn?printf|byte_)' $(SOURCES) || true
+

--- a/src/lcthw/darray_algos.c
+++ b/src/lcthw/darray_algos.c
@@ -1,5 +1,6 @@
 #include <lcthw/darray_algos.h>
 #include <stdlib.h>
+// #include <bsd/stdlib.h>
 
 int DArray_qsort(DArray * array, DArray_compare cmp)
 {

--- a/src/lcthw/darray_algos.c
+++ b/src/lcthw/darray_algos.c
@@ -1,6 +1,5 @@
 #include <lcthw/darray_algos.h>
 #include <stdlib.h>
-// #include <bsd/stdlib.h>
 
 int DArray_qsort(DArray * array, DArray_compare cmp)
 {

--- a/src/lcthw/stats.h
+++ b/src/lcthw/stats.h
@@ -1,6 +1,8 @@
 #ifndef lcthw_stats_h
 #define lcthw_stats_h
 
+#include <math.h>
+
 typedef struct Stats {
     double sum;
     double sumsq;


### PR DESCRIPTION
I was unable to compile the library under Ubuntu. One part was explained in #21 which can now be closed.

The changes in this PR, which added linker flags and some include statements, allowed me to successfully build it.