### PR TITLE
Makefile now works on multiple linux distributions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ TESTS=$(patsubst %.c,%,$(TEST_SRC))
 
 TARGET=build/liblcthw.a
 
-OS=$(shell lsb_release -si)
-ifeq ($(OS),Ubuntu)
+OS=$(shell uname -s)
+ifeq ($(OS),Linux)
 	LDLIBS=-llcthw -lbsd -L./build -lm
 endif
 


### PR DESCRIPTION
Changed the shell command that detects the distribution,
from `lsb_release -si` 
to `uname -s`
This should work on multiple linux distributions. tested on Arch.