### PR TITLE
Repeated values break Zed's bstrees

### DIFF
--- a/tests/bstree_tests.c
+++ b/tests/bstree_tests.c
@@ -122,7 +122,7 @@ char *test_fuzzing()
     srand((unsigned int)time(NULL));
 
     for (i = 0; i < 100; i++) {
-        int num = rand();
+        int num = rand() % 50;
         numbers[i] = bformat("%d", num);
         data[i] = bformat("data %d", num);
         BSTree_set(store, numbers[i], data[i]);


### PR DESCRIPTION
The bstree's cant handle repeated values. I'm getting both

[ERROR] (tests/bstree_tests.c:145: errno: None) Should get nothing.
[ERROR] (tests/bstree_tests.c:150: errno: None) Failed to get the right number.