### PR TITLE
Mitigating free(): invalid pointer on Windows and Linux

### DIFF
--- a/src/lcthw/list.c
+++ b/src/lcthw/list.c
@@ -16,6 +16,11 @@ void List_destroy(List * list)
 
     free(list->last);
     free(list);
+    
+    // Need to reset the count to zero to
+    // mitigating "free(): invalid pointer" error
+    // on Windows and Linux
+    list->count = 0;
 }
 
 void List_clear(List * list)

--- a/src/lcthw/list.c
+++ b/src/lcthw/list.c
@@ -26,7 +26,7 @@ void List_destroy(List * list)
 void List_clear(List * list)
 {
     LIST_FOREACH(list, first, next, cur) {
-        free(cur->value);
+        free(cur);
     }
 }
 


### PR DESCRIPTION
As I struggled to understand why the code did not work on either Windows and Linux but it worked fine on OSX, I finally figured it out, and it works like a charm as soon as the `list->count` is set to zero.