### PR TITLE
Fix Linux compatibility: sarray qsort_r signature, uname detection, CRLF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ TESTS=$(patsubst %.c,%,$(TEST_SRC))
 
 TARGET=build/liblcthw.a
 
-OS=$(shell lsb_release -si)
-ifeq ($(OS),Ubuntu)
+OS=$(shell uname -s)
+ifeq ($(OS),Linux)
 	LDLIBS=-llcthw -lbsd -L./build -lm
 endif
 

--- a/src/lcthw/sarray.c
+++ b/src/lcthw/sarray.c
@@ -1,27 +1,24 @@
+#define _GNU_SOURCE
 #undef NDEBUG
 #include <lcthw/sarray.h>
 #include <lcthw/dbg.h>
 #include <stdlib.h>
 
-
-int SuffixArray_compare(void *thunk, const void *a, const void *b)
+static int SuffixArray_compare(const void* a, const void* b, void* data)
 {
-    SuffixArray *sarry = thunk;
-    int a_at = *(int *)a;
-    int b_at = *(int *)b;
-    char *a_str = sarry->source + a_at;
-    char *b_str = sarry->source + b_at;
-
+    SuffixArray* sarry = data;
+    int a_at = *(int*)a;
+    int b_at = *(int*)b;
+    char* a_str = sarry->source + a_at;
+    char* b_str = sarry->source + b_at;
     int a_len = sarry->length - a_at;
     int b_len = sarry->length - b_at;
     int len = a_len < b_len ? a_len : b_len;
-
     int cmp = strncmp(a_str, b_str, len);
-
     return cmp;
 }
 
-int SuffixArray_find_suffix(SuffixArray *sarry, char *data, int length)
+int SuffixArray_find_suffix(SuffixArray* sarry, char* data, int length)
 {
     int min = 0;
     int max = sarry->length;
@@ -32,61 +29,56 @@ int SuffixArray_find_suffix(SuffixArray *sarry, char *data, int length)
         mid = (min + max) / 2;
         // BUG: wrong, need to use the minimum length
         cmp = strncmp(SuffixArray_substr(sarry, mid), data, length);
-
-        if(cmp < 0) {
+        if (cmp < 0) {
             min = mid + 1;
-        } else {
+        }
+        else {
             max = mid - 1;
         }
-    } while(cmp != 0 && min < max);
+    } while (cmp != 0 && min < max);
 
-    if(cmp == 0) {
+    if (cmp == 0) {
         return mid;
-    } else {
+    }
+    else {
         return -1;
     }
 }
 
-
-SuffixArray *SuffixArray_create(char *data, int length)
+SuffixArray* SuffixArray_create(char* data, int length)
 {
-    SuffixArray *sarry = calloc(1, sizeof(SuffixArray));
+    SuffixArray* sarry = calloc(1, sizeof(SuffixArray));
     check_mem(sarry);
 
     sarry->source = malloc(length + 1);
     check_mem(sarry->source);
     memcpy(sarry->source, data, length);
     sarry->source[length] = '\0';
-
     sarry->length = length;
 
     sarry->indices = malloc(length * sizeof(int));
     check_mem(sarry->indices);
 
     int i = 0;
-    for(i = 0; i < length; i++) {
+    for (i = 0; i < length; i++) {
         sarry->indices[i] = i;
     }
 
-    qsort_r(sarry->indices, length, sizeof(int), sarry, SuffixArray_compare);
+    qsort_r(sarry->indices, length, sizeof(int), SuffixArray_compare, sarry);
 
     return sarry;
-
 error:
-    if(sarry) {
+    if (sarry) {
         SuffixArray_destroy(sarry);
     }
-
     return NULL;
 }
 
-
-void SuffixArray_destroy(SuffixArray *sarry)
+void SuffixArray_destroy(SuffixArray* sarry)
 {
-    if(sarry) {
+    if (sarry) {
         free(sarry->source);
         free(sarry->indices);
         free(sarry);
     }
 }
-


### PR DESCRIPTION
Fix Linux compatibility: sarray.c qsort_r signature and Makefile OS detection

- Makefile: replace lsb_release -si/Ubuntu with uname -s/Linux for
  cross-distro compatibility (complements PR #24)
- sarray.c: add _GNU_SOURCE to expose qsort_r on glibc, fix argument
  order and fix parameter name thunk -> data